### PR TITLE
Add severity with Logback filter to have GCP logs at understand the level

### DIFF
--- a/email-validator/Dockerfile
+++ b/email-validator/Dockerfile
@@ -1,13 +1,14 @@
 FROM ghcr.io/graalvm/native-image:muslib-ol9-java17-22.3.2 AS graal
 WORKDIR /app
 COPY target/email-validator-1.0-SNAPSHOT.jar /app
-COPY reflect-config.json /app
+COPY reflect-config.json resource-config.json /app
 RUN ls -al /app
 RUN native-image \
     --no-fallback \
     -jar email-validator-1.0-SNAPSHOT.jar \
     --static \
     --libc=musl \
+    --resource-config=resource-config.json \
     -H:+ReportExceptionStackTraces \
     -H:ReflectionConfigurationFiles=reflect-config.json \
     -H:Name=email-validator

--- a/email-validator/Dockerfile
+++ b/email-validator/Dockerfile
@@ -1,15 +1,15 @@
 FROM ghcr.io/graalvm/native-image:muslib-ol9-java17-22.3.2 AS graal
 WORKDIR /app
-COPY target/email-validator-1.0-SNAPSHOT.jar /app
-COPY reflect-config.json resource-config.json /app
+COPY target/email-validator-1.0-SNAPSHOT.jar /app/
+COPY reflect-config.json resource-config.json /app/
 RUN ls -al /app
 RUN native-image \
     --no-fallback \
     -jar email-validator-1.0-SNAPSHOT.jar \
     --static \
     --libc=musl \
-    --resource-config=resource-config.json \
     -H:+ReportExceptionStackTraces \
+    -H:ResourceConfigurationFiles=resource-config.json \
     -H:ReflectionConfigurationFiles=reflect-config.json \
     -H:Name=email-validator
 

--- a/email-validator/pom.xml
+++ b/email-validator/pom.xml
@@ -49,9 +49,14 @@
       <version>2.0.7</version>
     </dependency>
     <dependency>
-      <groupId>com.hkupty.penna</groupId>
-      <artifactId>penna-core</artifactId>
-      <version>0.6.2</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.4.7</version>
+    </dependency>
+    <dependency>
+      <groupId>net.logstash.logback</groupId>
+        <artifactId>logstash-logback-encoder</artifactId>
+      <version>7.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/email-validator/reflect-config.json
+++ b/email-validator/reflect-config.json
@@ -42,5 +42,19 @@
     "queryAllPublicMethods": true,
     "queryAllPublicConstructors": true,
     "unsafeAllocated": true
+  },
+  {
+    "name" : "ch.qos.logback.core.ConsoleAppender",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicMethods": true,
+    "queryAllPublicConstructors": true,
+    "unsafeAllocated": true
   }
 ]

--- a/email-validator/reflect-config.json
+++ b/email-validator/reflect-config.json
@@ -56,5 +56,33 @@
     "queryAllPublicMethods": true,
     "queryAllPublicConstructors": true,
     "unsafeAllocated": true
+  },
+  {
+    "name" : "net.logstash.logback.encoder.LogstashEncoder",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicMethods": true,
+    "queryAllPublicConstructors": true,
+    "unsafeAllocated": true
+  },
+  {
+    "name" : "logging.SeverityAddingFilter",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allPublicMethods": true,
+    "allPublicFields": true,
+    "allPublicConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "queryAllPublicMethods": true,
+    "queryAllPublicConstructors": true,
+    "unsafeAllocated": true
   }
 ]

--- a/email-validator/resource-config.json
+++ b/email-validator/resource-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "pattern": "logback.xml",
+    "action": "copy"
+  }
+]

--- a/email-validator/resource-config.json
+++ b/email-validator/resource-config.json
@@ -1,6 +1,9 @@
-[
-  {
-    "pattern": "logback.xml",
-    "action": "copy"
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "logback.xml"
+      }
+    ]
   }
-]
+}

--- a/email-validator/src/main/java/logging/SeverityAddingFilter.java
+++ b/email-validator/src/main/java/logging/SeverityAddingFilter.java
@@ -1,0 +1,26 @@
+package logging;
+
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import org.slf4j.event.KeyValuePair;
+
+import java.util.List;
+
+public class SeverityAddingFilter extends Filter<LoggingEvent> {
+
+    @Override
+    public FilterReply decide(LoggingEvent event) {
+        try {
+            KeyValuePair severity = new KeyValuePair("severity", event.getLevel().levelStr);
+            if (event.getKeyValuePairs() != null) {
+                event.getKeyValuePairs().add(severity);
+            } else {
+                event.setKeyValuePairs(List.of(severity));
+            }
+        } catch (Exception e) {
+            System.out.printf("Error in SeverityAddingFilter, %s %s%n", e.getClass(), e.getMessage());
+        }
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/email-validator/src/main/resources/logback.xml
+++ b/email-validator/src/main/resources/logback.xml
@@ -1,6 +1,10 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+            </fieldNames>
+        </encoder>
         <filter class="logging.SeverityAddingFilter" />
     </appender>
 

--- a/email-validator/src/main/resources/logback.xml
+++ b/email-validator/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        <filter class="logging.SeverityAddingFilter" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
- Add severity with logback filter
- Include logback.xml in native image
- ChatGPT was wrong about the option name
- ChatGPT was wrong about the file format as well
- Add file needed Logbacks OptionHelper.instantiateByClassNameAndParameter
- More logback classes are instantiated via reflection
